### PR TITLE
chore: add @sircthulhu to the review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # routing list, not a claim about who contributes most: some entries are here
 # because the area is theirs, others because the role carries the repository.
 
-* @lllamnyp @androndo
+* @lllamnyp @androndo @sircthulhu


### PR DESCRIPTION
## What this PR does

The three people carrying this repository are @lllamnyp, @androndo and @sircthulhu; the routing list named only the first two.

Their direct collaborator grants have been levelled to match, and the access left over from this repository's community-etcd-operator origins has been cleared: five accounts outside the Cozystack organisation held `admin` or `maintain` here and no longer do. The `maintainers` team, which held read-only access, now has `push` — so the default stated in the header of this file (Cozystack maintainers are maintainers of every sub-project) is actually implemented rather than merely asserted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments for all project paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->